### PR TITLE
Fixes SSL errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 # Bring in our code to the container
 COPY xcel_itron2mqtt /opt/xcel_itron2mqtt


### PR DESCRIPTION
On newer versions of openssl/python the options to use TLS 1.2 have been removed. This pins the base image to a version that doesn't have this issue.